### PR TITLE
moved aiogoogle_creds decorator outside of Gmpart

### DIFF
--- a/GM/gmpart.py
+++ b/GM/gmpart.py
@@ -35,10 +35,8 @@ class TelegramBeautifulSoup(BeautifulSoup):
                     continue
             yield descendant
 
-
-# decorator  
 def aiogoogle_creds(func):
-    """Add aiogoogle for every wrapped function
+    """Add aiogoogle with credentials for every wrapped function
     """
     # WARNING: only for async functions!
     async def decor(self, *args, **kwargs):
@@ -225,7 +223,6 @@ class Gmpart():
         for message in messages_ids['messages']:
             raw_messages.append(
                 self.get_gmail_message(
-                    aiogoogle= aiogoogle,
                     id=message['id'],
                     user_creds=user_creds
                 )

--- a/GM/gmpart.py
+++ b/GM/gmpart.py
@@ -36,6 +36,20 @@ class TelegramBeautifulSoup(BeautifulSoup):
             yield descendant
 
 
+# decorator  
+def aiogoogle_creds(func):
+    """Add aiogoogle for every wrapped function
+    """
+    # WARNING: only for async functions!
+    async def decor(self, *args, **kwargs):
+        user_creds = kwargs.get('user_creds')
+        async with Aiogoogle(
+            client_creds=self.CLIENT_CREDS,
+            user_creds=user_creds
+        ) as aiogoogle:
+            return await func(self, aiogoogle, *args, **kwargs)
+    return decor
+
 class Gmpart():
     # TODO: save user_creds on exit from with
     # : try wrap all request to `async with as` in decorator
@@ -50,20 +64,6 @@ class Gmpart():
         self = Gmpart()
         self.CLIENT_CREDS = CLIENT_CREDS
         return self
-
-    def aiogoogle_creds(func):
-        """Add aiogoogle for every wrapped function
-        """
-        # WARNING: only for async functions!
-
-        async def decor(self, *args, **kwargs):
-            user_creds = kwargs.get('user_creds')
-            async with Aiogoogle(
-                client_creds=self.CLIENT_CREDS,
-                user_creds=user_creds
-            ) as aiogoogle:
-                return await func(self, aiogoogle, *args, **kwargs)
-        return decor
 
     @aiogoogle_creds
     async def authorize_uri(self, aiogoogle, email, state):
@@ -225,6 +225,7 @@ class Gmpart():
         for message in messages_ids['messages']:
             raw_messages.append(
                 self.get_gmail_message(
+                    aiogoogle= aiogoogle,
                     id=message['id'],
                     user_creds=user_creds
                 )


### PR DESCRIPTION
 **aiogoogle_creds** decorator was inside the Gmpart class, **pylint** was warning about it. 
The better option is to move it outside of the class, **what I did**.
The other possible options are to turn the decorator into a class or create an inner class (if an all-in-one class needed) 